### PR TITLE
Replace environment variables with fixed strings in default.vcl on start

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Convert environment variables in the conf to fixed entries
+# http://stackoverflow.com/questions/21056450/how-to-inject-environment-variables-in-varnish-configuration
+for name in VARNISH_BACKEND_PORT VARNISH_BACKEND_IP
+do
+    eval value=\$$name
+    sed -i "s|\${${name}}|${value}|g" /etc/varnish/default.vcl
+done
+
 # Start varnish and log
 varnishd -f /etc/varnish/default.vcl -s malloc,100M -a 0.0.0.0:${VARNISH_PORT}
 varnishlog


### PR DESCRIPTION
This change causes the start script to replace environment variables in default.vcl with their values.  This resolves issues with Varnish not starting due to configuration errors.  Resolves #2.
